### PR TITLE
Writeparall

### DIFF
--- a/src/Inputs.py
+++ b/src/Inputs.py
@@ -863,7 +863,7 @@ def extract_data(filename,inst,indf,param,domtraj,res,basetime,subnproc,filtrad=
 
         #Special case: wind module ff is computed from u and v
         if par[0:5]=="fgust" and "ff_uv" in indf.special_keys:
-            fs = comp_ff(par,lev,indf,filename,inst,basetime,domtraj,res,filtrad,subnproc)
+            fs = comp_ff(par,lev,filename,indf,inst,basetime,domtraj,res,filtrad,subnproc)
 
         #Special case: decumulate rain rate
         rrdecum, rrbefore = ifdecum(indf)

--- a/src/OBJ_Centre0D.py
+++ b/src/OBJ_Centre0D.py
@@ -419,8 +419,8 @@ class ObjectM:
                             isok = True
                             for ivi in range(4):
                                 isok = isok and (deriv[ivi]<dt or 2*deriv2[ivi]<dt)
-                            if isok:
-                                print("deriv T ok")
+                            #if isok:
+                            #    print("deriv T ok")
                         else:
                             isok=False
 

--- a/test_cases/inputs/algo_testcase2_parallel.json
+++ b/test_cases/inputs/algo_testcase2_parallel.json
@@ -8,6 +8,6 @@
 	"parres":{"all":0.5},
 	"specfields":{"track":"rv850","pairing":"mslp"},
 	"diag_parameter":["mslp_o","mslp_p"],
-	"parallel":{"ntasks":2,"subnproc":2}
+	"parallel":{"ntasks":2,"subnproc":2,"write_parall":"True"}
 }
 

--- a/test_cases/test_case2.py
+++ b/test_cases/test_case2.py
@@ -38,7 +38,7 @@ repout='./test2/'
 #PrepareFiles(repin+"algo_testcase2.json",repout+"indef_xtract.json",{"filter":"./tmp/case2/","dirout":repout},{'start':"2020100106",'final':"2020100112",'step':"06"},termtraj={'final':48,'step':3},members=[8,10])
 
 #a/ Compute track using the extracted grib files
-ltraj=track(repin+"algo_testcase2.json",repout+"indef_xtract.json",{'start':"2020100106",'final':"2020100112",'step':"06"},termtraj={'final':48,'step':3},members=[8,10],reftraj=repin+"ALEX_ANA.json",outfile=repout+'track_test_case2a_v'+str(traject_version)+'.json',plotfile=repout+'track_test_case2a_v'+str(traject_version)+'.png')
+ltraj=track(repin+"algo_testcase2_parallel.json",repout+"indef_xtract.json",{'start':"2020100106",'final':"2020100112",'step':"06"},termtraj={'final':48,'step':3},members=[8,10],reftraj=repin+"ALEX_ANA.json",outfile=repout+'track_test_case2a_v'+str(traject_version)+'.json',plotfile=repout+'track_test_case2a_v'+str(traject_version)+'.png')
 
 #b/ Compute track using the domain-filtered data
 #ltraj=track(repin+"algo_testcase2.json",repout+"indef_filter.json",{'start':"2020100106",'final':"2020100112",'step':"06"},termtraj={'final':48,'step':3},reftraj=repin+"ALEX_ANA.json",outfile=repout+'track_test_case2b_v'+str(traject_version)+'.json',plotfile=repout+'track_test_case2b_v'+str(traject_version)+'.png',members=[8,10])


### PR DESCRIPTION
This contribution enables to write in parallel the output files.
This is parametrized in the "parallel" namelist.
This is particularly relevant for forecast data on several members, when running on a HPC.